### PR TITLE
Fix ld-linux-aarch64.so.1: No such file or directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM dockage/alpine:3.16.7
 
 ENV MAILCATCHER_VERSION=0.9.0
 
-RUN apk --no-cache --update add build-base ruby ruby-dev ruby-json ruby-etc sqlite-dev \
+RUN apk --no-cache --update add build-base ruby ruby-dev ruby-json ruby-etc sqlite-dev gcompat \
     && gem install mailcatcher:${MAILCATCHER_VERSION} --no-document \
     && apk del --rdepends --purge build-base
 


### PR DESCRIPTION
This PR fix the error message for ARM host for a missing dependancy for the sqlite gem.

Reference: https://github.com/dockage/mailcatcher/issues/9
