### PR TITLE
Install pure Ruby sqlite3 gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM dockage/alpine:3.16.7
 ENV MAILCATCHER_VERSION=0.9.0
 
 RUN apk --no-cache --update add build-base ruby ruby-dev ruby-json ruby-etc sqlite-dev \
+    && gem install sqlite3 --no-document --platform ruby \
     && gem install mailcatcher:${MAILCATCHER_VERSION} --no-document \
     && apk del --rdepends --purge build-base
 


### PR DESCRIPTION
The Docker images pushed to Docker Hub for tagged versions `latest`, `0`, `0.9`, and `0.9.0` ([link](https://hub.docker.com/r/dockage/mailcatcher/tags)), published on 22 August 2023, include several notable changes ([compare](https://github.com/dockage/mailcatcher/compare/v0.8.2...v0.9.0)):

- Alpine Linux update from 3.15.4 to 3.16.7 ([release history](https://alpinelinux.org/releases/))
- Mailcatcher 0.8.2 to 0.9.0

The former is significant as it includes a Ruby update from 3.0.4 to 3.1.4, though I don't believe that is introducing the issues detailed in dockage/mailcatcher#9.

The latter is significant as the build updates this gem's sqlite3 dependency from 1.4.4 (pure Ruby gem) to 1.6.3 (platform-native gem). The sqlite3 gem introduced platform-native builds from 1.5.0 ([RubyGems version history](https://rubygems.org/gems/sqlite3/versions)), first published in July/September 2022.

As noted in the aforementioned issue, the published Docker images for ARM platforms are failing to launch.

dockage/mailcatcher#10 proposes adding the `gcompat` package to install glibc-compatible libraries into Alpine. I've used that on other projects running Alpine Linux to install Nokogiri, etc. Unfortunately, as I note in [my comment on that PR](https://github.com/dockage/mailcatcher/pull/10#issuecomment-1841147271), the resulting image crashes on a _different_ error.

The proposed change here (reintroducing the pure Ruby sqlite3 gem) works around what might be a rabbit hole of issues I'm not equipped to solve.

This _does_ result in longer Docker image build times, but I don't think that will negatively impact downstream consumers of the published images.

Addresses dockage/mailcatcher#9.
